### PR TITLE
feat(redesign): editorial OG/share images for home, blog, blog post

### DIFF
--- a/src/app/blog/opengraph-image.tsx
+++ b/src/app/blog/opengraph-image.tsx
@@ -1,125 +1,125 @@
-import { ImageResponse } from 'next/og'
+import { ImageResponse } from "next/og";
+import { loadGoogleFont } from "../components/utils/og-fonts";
 
-export const runtime = 'edge'
- 
-export const alt = "SSM's Blog - Tech Insights & Development Tips"
-export const size = {
-  width: 1200,
-  height: 630,
-}
-export const contentType = 'image/png'
- 
-export default async function Image({ params }: { params: { slug: string } }) {
-  
+export const runtime = "edge";
+
+export const alt = "Journal — Subhra Sekhar | Writing on Engineering & Practice";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const TITLE = "From the journal.";
+const LEDE =
+  "Notes from practice — engineering decisions, architecture sketches, and the occasional opinion.";
+const KICKER = "JOURNAL · SUBHRA SEKHAR";
+const FOOTER_LEFT = "SSM · MMVI · KOLKATA";
+const FOOTER_RIGHT = "subhrasekhar.in/blog";
+
+export default async function Image() {
+  const [serif, mono, sans] = await Promise.all([
+    loadGoogleFont("Fraunces", TITLE, 500),
+    loadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
+    loadGoogleFont("Inter", LEDE, 400),
+  ]);
+
   return new ImageResponse(
     (
       <div
         style={{
-          background: 'linear-gradient(135deg, #0ea5e9 0%, #d946ef 50%, #f97316 100%)',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'white',
-          fontFamily: 'Inter, system-ui, sans-serif',
+          background: "#12263A",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          padding: "80px",
+          color: "#F7F3EC",
+          position: "relative",
+          fontFamily: "Inter",
         }}
       >
         <div
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginBottom: '32px',
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 8,
+            background: "#B8895A",
           }}
-        >
-          <div
-            style={{
-              width: '100px',
-              height: '100px',
-              background: 'rgba(255, 255, 255, 0.15)',
-              borderRadius: '20px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '48px',
-              marginRight: '24px',
-            }}
-          >
-            📝
-          </div>
-          <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column' }}>
-            <h1
-              style={{
-                fontSize: '56px',
-                fontWeight: '700',
-                margin: '0',
-                marginBottom: '8px',
-                background: 'linear-gradient(90deg, #ffffff 0%, #e0f2fe 100%)',
-                backgroundClip: 'text',
-                color: 'transparent',
-              }}
-            >
-              SSM's Blog
-            </h1>
-            <p
-              style={{
-                fontSize: '24px',
-                fontWeight: '400',
-                margin: '0',
-                opacity: '0.9',
-              }}
-            >
-              Tech Insights & Development Tips
-            </p>
-          </div>
-        </div>
+        />
+
         <div
           style={{
-            display: 'flex',
-            gap: '20px',
-            marginTop: '24px',
+            display: "flex",
+            fontFamily: "JetBrains Mono",
+            fontSize: 18,
+            letterSpacing: 4,
+            textTransform: "uppercase",
+            color: "#B8895A",
+            marginBottom: 32,
           }}
         >
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '10px 20px',
-              borderRadius: '10px',
-              fontSize: '16px',
-              fontWeight: '500',
-            }}
-          >
-            Full Stack Development
-          </div>
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '10px 20px',
-              borderRadius: '10px',
-              fontSize: '16px',
-              fontWeight: '500',
-            }}
-          >
-            Tech Tutorials
-          </div>
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '10px 20px',
-              borderRadius: '10px',
-              fontSize: '16px',
-              fontWeight: '500',
-            }}
-          >
-            Industry Insights
-          </div>
+          {KICKER}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontFamily: "Fraunces",
+            fontSize: 116,
+            fontWeight: 500,
+            letterSpacing: -2,
+            lineHeight: 1,
+            color: "#F7F3EC",
+          }}
+        >
+          {TITLE}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontFamily: "Inter",
+            fontSize: 28,
+            lineHeight: 1.5,
+            color: "rgba(247,243,236,0.8)",
+            marginTop: 40,
+            maxWidth: 880,
+          }}
+        >
+          {LEDE}
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            bottom: 60,
+            left: 80,
+            right: 80,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingTop: 24,
+            borderTop: "1px solid rgba(247,243,236,0.18)",
+            fontFamily: "JetBrains Mono",
+            fontSize: 16,
+            letterSpacing: 3,
+            textTransform: "uppercase",
+            color: "rgba(247,243,236,0.6)",
+          }}
+        >
+          <span>{FOOTER_LEFT}</span>
+          <span style={{ color: "#B8895A" }}>{FOOTER_RIGHT}</span>
         </div>
       </div>
     ),
     {
       ...size,
-    }
-  )
+      fonts: [
+        { name: "Fraunces", data: serif, style: "normal", weight: 500 },
+        { name: "Inter", data: sans, style: "normal", weight: 400 },
+        { name: "JetBrains Mono", data: mono, style: "normal", weight: 500 },
+      ],
+      headers: { "cache-control": "public, max-age=31536000, immutable" },
+    },
+  );
 }

--- a/src/app/blog/posts/[slug]/opengraph-image.tsx
+++ b/src/app/blog/posts/[slug]/opengraph-image.tsx
@@ -1,152 +1,122 @@
-import { ImageResponse } from 'next/og'
+import { ImageResponse } from "next/og";
+import { loadGoogleFont } from "../../../components/utils/og-fonts";
 
-export const runtime = 'edge'
- 
-export const alt = "SSM's Blog Post"
-export const size = {
-  width: 1200,
-  height: 630,
-}
-export const contentType = 'image/png'
+export const runtime = "edge";
 
-// Function to convert slug to readable title
+export const alt = "Subhra Sekhar — Journal";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
 function slugToTitle(slug: string): string {
   return slug
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
- 
+
+const KICKER = "JOURNAL · SUBHRA SEKHAR";
+const FOOTER_LEFT = "BY SUBHRA SEKHAR MUKHERJEE";
+const FOOTER_RIGHT = "subhrasekhar.in/blog";
+
 export default async function Image({ params }: { params: { slug: string } }) {
-  // Convert slug to a readable title
-  const title = slugToTitle(params.slug)
-  
-  // Truncate title if too long
-  const displayTitle = title.length > 60 ? title.substring(0, 57) + '...' : title
-  
+  const title = slugToTitle(params.slug);
+  const displayTitle = title.length > 90 ? title.substring(0, 87) + "…" : title;
+
+  const [serif, mono, sans] = await Promise.all([
+    loadGoogleFont("Fraunces", displayTitle, 500),
+    loadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
+    loadGoogleFont("Inter", "An article from the Subhra Sekhar journal.", 400),
+  ]);
+
+  // Scale title size by length so long titles still fit
+  const titleSize = displayTitle.length > 70 ? 60 : displayTitle.length > 40 ? 78 : 96;
+
   return new ImageResponse(
     (
       <div
         style={{
-          background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'white',
-          fontFamily: 'Inter, system-ui, sans-serif',
-          padding: '60px',
+          background: "#12263A",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          padding: "80px",
+          color: "#F7F3EC",
+          position: "relative",
+          fontFamily: "Inter",
         }}
       >
         <div
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginBottom: '40px',
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 8,
+            background: "#B8895A",
           }}
-        >
-          <div
-            style={{
-              width: '80px',
-              height: '80px',
-              background: 'rgba(255, 255, 255, 0.15)',
-              borderRadius: '16px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '36px',
-              marginRight: '20px',
-            }}
-          >
-            📖
-          </div>
-          <div style={{ fontSize: '20px', opacity: '0.9', fontWeight: '500' }}>
-            SSM's Blog
-          </div>
-        </div>
-        
-        <div style={{ textAlign: 'center', maxWidth: '1000px', display: 'flex', flexDirection: 'column' }}>
-          <h1
-            style={{
-              fontSize: displayTitle.length > 40 ? '36px' : '42px',
-              fontWeight: '700',
-              margin: '0',
-              marginBottom: '20px',
-              background: 'linear-gradient(90deg, #ffffff 0%, #f0f9ff 100%)',
-              backgroundClip: 'text',
-              color: 'transparent',
-              lineHeight: '1.2',
-            }}
-          >
-            {displayTitle}
-          </h1>
-          
-          <p
-            style={{
-              fontSize: '18px',
-              fontWeight: '400',
-              margin: '0',
-              opacity: '0.85',
-              lineHeight: '1.4',
-              maxWidth: '900px',
-            }}
-          >
-            Tech insights and development tips from a Full Stack Developer
-          </p>
-        </div>
-        
+        />
+
         <div
           style={{
-            display: 'flex',
-            gap: '16px',
-            marginTop: '32px',
+            display: "flex",
+            fontFamily: "JetBrains Mono",
+            fontSize: 18,
+            letterSpacing: 4,
+            textTransform: "uppercase",
+            color: "#B8895A",
+            marginBottom: 32,
           }}
         >
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '8px 16px',
-              borderRadius: '8px',
-              fontSize: '14px',
-              fontWeight: '500',
-            }}
-          >
-            Full Stack Development
-          </div>
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '8px 16px',
-              borderRadius: '8px',
-              fontSize: '14px',
-              fontWeight: '500',
-            }}
-          >
-            Technical Tutorial
-          </div>
+          {KICKER}
         </div>
-        
+
         <div
           style={{
-            position: 'absolute',
-            bottom: '40px',
-            right: '60px',
-            background: 'rgba(255, 255, 255, 0.1)',
-            padding: '8px 16px',
-            borderRadius: '8px',
-            fontSize: '14px',
-            fontWeight: '500',
+            display: "flex",
+            fontFamily: "Fraunces",
+            fontSize: titleSize,
+            fontWeight: 500,
+            letterSpacing: -1.5,
+            lineHeight: 1.05,
+            color: "#F7F3EC",
+            maxWidth: 1040,
           }}
         >
-          Subhra Sekhar Mukherjee
+          {displayTitle}
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            bottom: 60,
+            left: 80,
+            right: 80,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingTop: 24,
+            borderTop: "1px solid rgba(247,243,236,0.18)",
+            fontFamily: "JetBrains Mono",
+            fontSize: 16,
+            letterSpacing: 3,
+            textTransform: "uppercase",
+            color: "rgba(247,243,236,0.6)",
+          }}
+        >
+          <span>{FOOTER_LEFT}</span>
+          <span style={{ color: "#B8895A" }}>{FOOTER_RIGHT}</span>
         </div>
       </div>
     ),
     {
       ...size,
-    }
-  )
+      fonts: [
+        { name: "Fraunces", data: serif, style: "normal", weight: 500 },
+        { name: "Inter", data: sans, style: "normal", weight: 400 },
+        { name: "JetBrains Mono", data: mono, style: "normal", weight: 500 },
+      ],
+      headers: { "cache-control": "public, max-age=31536000, immutable" },
+    },
+  );
 }

--- a/src/app/components/utils/og-fonts.ts
+++ b/src/app/components/utils/og-fonts.ts
@@ -1,0 +1,34 @@
+/**
+ * Loads a Google Font binary at edge runtime so it can be passed to
+ * `next/og` ImageResponse as a font source.
+ *
+ * Returns the raw font ArrayBuffer for the requested family + weight.
+ * Pass the `text` that will appear in the rendered image to keep the
+ * subset small (Google returns only the glyphs it needs).
+ */
+export async function loadGoogleFont(
+  family: string,
+  text: string,
+  weight = 500,
+): Promise<ArrayBuffer> {
+  const url = `https://fonts.googleapis.com/css2?family=${family.replace(
+    / /g,
+    "+",
+  )}:wght@${weight}&text=${encodeURIComponent(text)}`;
+
+  const css = await (
+    await fetch(url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+      },
+    })
+  ).text();
+
+  const match = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype|woff2)'\)/);
+  if (!match) throw new Error(`Failed to find font URL for ${family} ${weight}`);
+
+  const fontRes = await fetch(match[1]);
+  if (!fontRes.ok) throw new Error(`Failed to fetch font binary for ${family} ${weight}`);
+  return await fontRes.arrayBuffer();
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,134 +1,125 @@
-import { ImageResponse } from 'next/og'
+import { ImageResponse } from "next/og";
+import { loadGoogleFont } from "./components/utils/og-fonts";
 
-// Route segment config
-export const runtime = 'edge'
- 
-// Image metadata
-export const alt = "Full Stack Developer | Front & Back-End Expert"
-export const size = {
-  width: 1200,
-  height: 630,
-}
- 
-export const contentType = 'image/png'
- 
-// Image generation
+export const runtime = "edge";
+
+export const alt = "Subhra Sekhar — Full Stack Developer & Tech Consultant";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const TITLE = "Subhra Sekhar.";
+const LEDE =
+  "An editorial, engineering-first practice. Full-stack work for teams that care about clarity, calm interfaces, and software that behaves well in the wild.";
+const KICKER = "PRACTICE · v1.0";
+const FOOTER_LEFT = "SSM · MMVI · KOLKATA";
+const FOOTER_RIGHT = "subhrasekhar.in";
+
 export default async function Image() {
- 
+  const [serif, mono, sans] = await Promise.all([
+    loadGoogleFont("Fraunces", TITLE, 500),
+    loadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
+    loadGoogleFont("Inter", LEDE, 400),
+  ]);
+
   return new ImageResponse(
     (
-      // ImageResponse JSX element
       <div
         style={{
-          background: 'linear-gradient(135deg, #0ea5e9 0%, #d946ef 100%)',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'white',
-          fontFamily: 'Inter, system-ui, sans-serif',
+          background: "#12263A",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          padding: "80px",
+          color: "#F7F3EC",
+          position: "relative",
+          fontFamily: "Inter",
         }}
       >
         <div
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginBottom: '24px',
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 8,
+            background: "#B8895A",
           }}
-        >
-          <div
-            style={{
-              width: '120px',
-              height: '120px',
-              background: 'rgba(255, 255, 255, 0.1)',
-              borderRadius: '24px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '64px',
-              marginRight: '32px',
-            }}
-          >
-            💻
-          </div>
-          <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column' }}>
-            <h1
-              style={{
-                fontSize: '48px',
-                fontWeight: '700',
-                margin: '0',
-                marginBottom: '8px',
-                background: 'linear-gradient(90deg, #ffffff 0%, #e0f2fe 100%)',
-                backgroundClip: 'text',
-                color: 'transparent',
-              }}
-            >
-              Subhra Sekhar Mukherjee
-            </h1>
-            <p
-              style={{
-                fontSize: '28px',
-                fontWeight: '400',
-                margin: '0',
-                opacity: '0.9',
-              }}
-            >
-              Full Stack Developer | Front & Back-End Expert
-            </p>
-          </div>
-        </div>
+        />
+
         <div
           style={{
-            display: 'flex',
-            gap: '24px',
-            marginTop: '32px',
+            display: "flex",
+            fontFamily: "JetBrains Mono",
+            fontSize: 18,
+            letterSpacing: 4,
+            textTransform: "uppercase",
+            color: "#B8895A",
+            marginBottom: 32,
           }}
         >
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '12px 24px',
-              borderRadius: '12px',
-              fontSize: '18px',
-              fontWeight: '500',
-            }}
-          >
-            13+ Years Experience
-          </div>
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '12px 24px',
-              borderRadius: '12px',
-              fontSize: '18px',
-              fontWeight: '500',
-            }}
-          >
-            100+ Projects
-          </div>
-          <div
-            style={{
-              background: 'rgba(255, 255, 255, 0.1)',
-              padding: '12px 24px',
-              borderRadius: '12px',
-              fontSize: '18px',
-              fontWeight: '500',
-            }}
-          >
-            Full Stack Expert
-          </div>
+          {KICKER}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontFamily: "Fraunces",
+            fontSize: 132,
+            fontWeight: 500,
+            letterSpacing: -2,
+            lineHeight: 1,
+            color: "#F7F3EC",
+          }}
+        >
+          {TITLE}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontFamily: "Inter",
+            fontSize: 26,
+            lineHeight: 1.5,
+            color: "rgba(247,243,236,0.8)",
+            marginTop: 40,
+            maxWidth: 880,
+          }}
+        >
+          {LEDE}
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            bottom: 60,
+            left: 80,
+            right: 80,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingTop: 24,
+            borderTop: "1px solid rgba(247,243,236,0.18)",
+            fontFamily: "JetBrains Mono",
+            fontSize: 16,
+            letterSpacing: 3,
+            textTransform: "uppercase",
+            color: "rgba(247,243,236,0.6)",
+          }}
+        >
+          <span>{FOOTER_LEFT}</span>
+          <span style={{ color: "#B8895A" }}>{FOOTER_RIGHT}</span>
         </div>
       </div>
     ),
-    // ImageResponse options
     {
-      // For convenience, we can re-use the exported opengraph-image
-      // size config to also set the ImageResponse's width and height.
       ...size,
-      headers: { 'cache-control': 'public, max-age=31536000, immutable' }
-    }
-  )
+      fonts: [
+        { name: "Fraunces", data: serif, style: "normal", weight: 500 },
+        { name: "Inter", data: sans, style: "normal", weight: 400 },
+        { name: "JetBrains Mono", data: mono, style: "normal", weight: 500 },
+      ],
+      headers: { "cache-control": "public, max-age=31536000, immutable" },
+    },
+  );
 }


### PR DESCRIPTION
The three opengraph-image routes were still rendering bright cyan/magenta gradients with emoji and rounded pills — completely off-system from the new editorial site. Replaced all three:

- Navy (#12263A) background with an 8px tan accent rule along the top
- JetBrains Mono kicker label up top
- Fraunces serif title (~120px on home/blog, scaled to fit on post)
- Inter sans lede where appropriate
- Mono colophon row at the bottom (SSM · MMVI · KOLKATA / subhrasekhar.in) separated by a hairline rule, paper text at 60% opacity

Fonts loaded at edge runtime via a new og-fonts.ts helper that hits the Google Fonts CSS API and pipes the woff2 binary into ImageResponse.