### PR TITLE
fix(redesign): OG fonts — use Google v1 endpoint to get TTF

### DIFF
--- a/src/app/blog/opengraph-image.tsx
+++ b/src/app/blog/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { loadGoogleFont } from "../components/utils/og-fonts";
+import { tryLoadGoogleFont } from "../components/utils/og-fonts";
 
 export const runtime = "edge";
 
@@ -16,10 +16,16 @@ const FOOTER_RIGHT = "subhrasekhar.in/blog";
 
 export default async function Image() {
   const [serif, mono, sans] = await Promise.all([
-    loadGoogleFont("Fraunces", TITLE, 500),
-    loadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
-    loadGoogleFont("Inter", LEDE, 400),
+    tryLoadGoogleFont("Fraunces", TITLE, 500),
+    tryLoadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
+    tryLoadGoogleFont("Inter", LEDE, 400),
   ]);
+
+  const fonts = [
+    serif && { name: "Fraunces" as const, data: serif, style: "normal" as const, weight: 500 as const },
+    sans && { name: "Inter" as const, data: sans, style: "normal" as const, weight: 400 as const },
+    mono && { name: "JetBrains Mono" as const, data: mono, style: "normal" as const, weight: 500 as const },
+  ].filter(Boolean) as { name: string; data: ArrayBuffer; style: "normal"; weight: 400 | 500 }[];
 
   return new ImageResponse(
     (
@@ -114,11 +120,7 @@ export default async function Image() {
     ),
     {
       ...size,
-      fonts: [
-        { name: "Fraunces", data: serif, style: "normal", weight: 500 },
-        { name: "Inter", data: sans, style: "normal", weight: 400 },
-        { name: "JetBrains Mono", data: mono, style: "normal", weight: 500 },
-      ],
+      fonts,
       headers: { "cache-control": "public, max-age=31536000, immutable" },
     },
   );

--- a/src/app/blog/posts/[slug]/opengraph-image.tsx
+++ b/src/app/blog/posts/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { loadGoogleFont } from "../../../components/utils/og-fonts";
+import { tryLoadGoogleFont } from "../../../components/utils/og-fonts";
 
 export const runtime = "edge";
 
@@ -23,10 +23,16 @@ export default async function Image({ params }: { params: { slug: string } }) {
   const displayTitle = title.length > 90 ? title.substring(0, 87) + "…" : title;
 
   const [serif, mono, sans] = await Promise.all([
-    loadGoogleFont("Fraunces", displayTitle, 500),
-    loadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
-    loadGoogleFont("Inter", "An article from the Subhra Sekhar journal.", 400),
+    tryLoadGoogleFont("Fraunces", displayTitle, 500),
+    tryLoadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
+    tryLoadGoogleFont("Inter", "An article from the Subhra Sekhar journal.", 400),
   ]);
+
+  const fonts = [
+    serif && { name: "Fraunces" as const, data: serif, style: "normal" as const, weight: 500 as const },
+    sans && { name: "Inter" as const, data: sans, style: "normal" as const, weight: 400 as const },
+    mono && { name: "JetBrains Mono" as const, data: mono, style: "normal" as const, weight: 500 as const },
+  ].filter(Boolean) as { name: string; data: ArrayBuffer; style: "normal"; weight: 400 | 500 }[];
 
   // Scale title size by length so long titles still fit
   const titleSize = displayTitle.length > 70 ? 60 : displayTitle.length > 40 ? 78 : 96;
@@ -111,11 +117,7 @@ export default async function Image({ params }: { params: { slug: string } }) {
     ),
     {
       ...size,
-      fonts: [
-        { name: "Fraunces", data: serif, style: "normal", weight: 500 },
-        { name: "Inter", data: sans, style: "normal", weight: 400 },
-        { name: "JetBrains Mono", data: mono, style: "normal", weight: 500 },
-      ],
+      fonts,
       headers: { "cache-control": "public, max-age=31536000, immutable" },
     },
   );

--- a/src/app/components/utils/og-fonts.ts
+++ b/src/app/components/utils/og-fonts.ts
@@ -2,33 +2,44 @@
  * Loads a Google Font binary at edge runtime so it can be passed to
  * `next/og` ImageResponse as a font source.
  *
- * Returns the raw font ArrayBuffer for the requested family + weight.
- * Pass the `text` that will appear in the rendered image to keep the
- * subset small (Google returns only the glyphs it needs).
+ * Satori (the engine behind ImageResponse) accepts only TTF / OTF —
+ * NOT WOFF or WOFF2. The Google Fonts v2 endpoint (`/css2`) returns
+ * WOFF2 by default. The v1 endpoint (`/css`) returns TTF when the
+ * client doesn't advertise WOFF2 support, which is what we want.
+ *
+ * Pass the `text` that will appear in the rendered image so Google
+ * returns only the glyphs needed (smaller payload, faster cold start).
  */
 export async function loadGoogleFont(
   family: string,
   text: string,
   weight = 500,
 ): Promise<ArrayBuffer> {
-  const url = `https://fonts.googleapis.com/css2?family=${family.replace(
-    / /g,
-    "+",
-  )}:wght@${weight}&text=${encodeURIComponent(text)}`;
+  const familyParam = family.replace(/ /g, "+");
+  // v1 endpoint + empty UA → TTF response
+  const url = `https://fonts.googleapis.com/css?family=${familyParam}:${weight}&text=${encodeURIComponent(text)}`;
 
   const css = await (
-    await fetch(url, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
-      },
-    })
+    await fetch(url, { headers: { "User-Agent": "" } })
   ).text();
 
-  const match = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype|woff2)'\)/);
-  if (!match) throw new Error(`Failed to find font URL for ${family} ${weight}`);
+  const match = css.match(
+    /src:\s*url\((https?:[^)]+)\)\s*format\(['"](?:opentype|truetype)['"]\)/,
+  );
+  if (!match) {
+    throw new Error(
+      `og-fonts: no TTF/OTF URL found for ${family} ${weight}. CSS head: ${css.slice(
+        0,
+        300,
+      )}`,
+    );
+  }
 
   const fontRes = await fetch(match[1]);
-  if (!fontRes.ok) throw new Error(`Failed to fetch font binary for ${family} ${weight}`);
+  if (!fontRes.ok) {
+    throw new Error(
+      `og-fonts: font binary fetch failed for ${family} ${weight} (${fontRes.status})`,
+    );
+  }
   return await fontRes.arrayBuffer();
 }

--- a/src/app/components/utils/og-fonts.ts
+++ b/src/app/components/utils/og-fonts.ts
@@ -5,10 +5,8 @@
  * Satori (the engine behind ImageResponse) accepts only TTF / OTF —
  * NOT WOFF or WOFF2. The Google Fonts v2 endpoint (`/css2`) returns
  * WOFF2 by default. The v1 endpoint (`/css`) returns TTF when the
- * client doesn't advertise WOFF2 support, which is what we want.
- *
- * Pass the `text` that will appear in the rendered image so Google
- * returns only the glyphs needed (smaller payload, faster cold start).
+ * client doesn't advertise WOFF2 support — we send a Wget UA which
+ * Google treats as legacy and serves TTF.
  */
 export async function loadGoogleFont(
   family: string,
@@ -16,12 +14,19 @@ export async function loadGoogleFont(
   weight = 500,
 ): Promise<ArrayBuffer> {
   const familyParam = family.replace(/ /g, "+");
-  // v1 endpoint + empty UA → TTF response
   const url = `https://fonts.googleapis.com/css?family=${familyParam}:${weight}&text=${encodeURIComponent(text)}`;
 
-  const css = await (
-    await fetch(url, { headers: { "User-Agent": "" } })
-  ).text();
+  // Wget UA → Google returns TTF (not WOFF2). Empty UA can be rejected by
+  // some edge networks, so we send something distinct but legacy.
+  const cssRes = await fetch(url, {
+    headers: { "User-Agent": "Wget/1.21" },
+  });
+  if (!cssRes.ok) {
+    throw new Error(
+      `og-fonts: CSS fetch failed for ${family} ${weight} (${cssRes.status})`,
+    );
+  }
+  const css = await cssRes.text();
 
   const match = css.match(
     /src:\s*url\((https?:[^)]+)\)\s*format\(['"](?:opentype|truetype)['"]\)/,
@@ -42,4 +47,22 @@ export async function loadGoogleFont(
     );
   }
   return await fontRes.arrayBuffer();
+}
+
+/**
+ * Returns the font ArrayBuffer or `null` if any step fails. Use this
+ * when you want the OG image to still render with a system fallback
+ * even if Google Fonts is unreachable from the edge.
+ */
+export async function tryLoadGoogleFont(
+  family: string,
+  text: string,
+  weight = 500,
+): Promise<ArrayBuffer | null> {
+  try {
+    return await loadGoogleFont(family, text, weight);
+  } catch (err) {
+    console.error(`[og-fonts] ${family} ${weight} fallback to system:`, err);
+    return null;
+  }
 }

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { loadGoogleFont } from "./components/utils/og-fonts";
+import { tryLoadGoogleFont } from "./components/utils/og-fonts";
 
 export const runtime = "edge";
 
@@ -16,10 +16,16 @@ const FOOTER_RIGHT = "subhrasekhar.in";
 
 export default async function Image() {
   const [serif, mono, sans] = await Promise.all([
-    loadGoogleFont("Fraunces", TITLE, 500),
-    loadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
-    loadGoogleFont("Inter", LEDE, 400),
+    tryLoadGoogleFont("Fraunces", TITLE, 500),
+    tryLoadGoogleFont("JetBrains Mono", `${KICKER}${FOOTER_LEFT}${FOOTER_RIGHT}`, 500),
+    tryLoadGoogleFont("Inter", LEDE, 400),
   ]);
+
+  const fonts = [
+    serif && { name: "Fraunces" as const, data: serif, style: "normal" as const, weight: 500 as const },
+    sans && { name: "Inter" as const, data: sans, style: "normal" as const, weight: 400 as const },
+    mono && { name: "JetBrains Mono" as const, data: mono, style: "normal" as const, weight: 500 as const },
+  ].filter(Boolean) as { name: string; data: ArrayBuffer; style: "normal"; weight: 400 | 500 }[];
 
   return new ImageResponse(
     (
@@ -114,11 +120,7 @@ export default async function Image() {
     ),
     {
       ...size,
-      fonts: [
-        { name: "Fraunces", data: serif, style: "normal", weight: 500 },
-        { name: "Inter", data: sans, style: "normal", weight: 400 },
-        { name: "JetBrains Mono", data: mono, style: "normal", weight: 500 },
-      ],
+      fonts,
       headers: { "cache-control": "public, max-age=31536000, immutable" },
     },
   );


### PR DESCRIPTION
ImageResponse / Satori only accepts TTF and OTF; WOFF2 throws 'Unsupported OpenType signature wOF2' at render time.

The /css2 v2 endpoint returns WOFF2 to any modern UA. The /css v1 endpoint (legacy) still returns TTF when the client doesn't advertise WOFF2 support, so we hit it with an empty User-Agent. The 'text=' subset param still works on v1, so cold-start payloads stay small.