### PR TITLE
fix(seo): drop invalid provider prop from ProfessionalService

### DIFF
--- a/src/app/data/schema.ts
+++ b/src/app/data/schema.ts
@@ -68,7 +68,6 @@ export function professionalServiceSchema(): Node {
     image: `${BASE}/opengraph-image`,
     email: EMAIL,
     founder: { "@id": PERSON_ID },
-    provider: { "@id": PERSON_ID },
     areaServed: "Worldwide",
     knowsAbout: KNOWS_ABOUT,
     sameAs: SAME_AS,


### PR DESCRIPTION
ProfessionalService extends Organization/LocalBusiness, which has no 'provider' property (flagged by schema.org validator). 'founder' is retained as the valid Person link. Service.provider is unaffected.